### PR TITLE
do not replace backslash-escaped variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,38 @@
 module.exports = replace
 
 function replace (str, env) {
-  return str.replace(/\$({)?([a-z0-9_]+)(:-[^}]+)?(})?/gi, replacer(env || {}))
+  return str.replace(/(\\*)\$({)?([a-z0-9_]+)(:-[^}]+)?(})?/gi, replacer(env || {}))
 }
 
 function replacer (env) {
   return Array.isArray(env) ? replaceArray : replaceEnv
 
-  function replaceArray (_, start, key, def, end) {
+  function replaceArray (input, escapes, start, key, def, end) {
+    if (isEscaped(escapes)) {
+      // Only cut off 1 backslash so the shell that the output will probably be sent to can resolve the remaining ones
+      // (this way users don't have to triple-escape their stuff)
+      return input.slice(1)
+    }
+
     for (var i = 0; i < env.length; i++) {
       if (env[i][key]) return env[i][key]
     }
-    return defaultValue(start, def, end)
+    return escapes + defaultValue(start, def, end)
   }
 
-  function replaceEnv (_, start, key, def, end) {
-    return env[key] || defaultValue(start, def, end)
+  function replaceEnv (input, escapes, start, key, def, end) {
+    if (isEscaped(escapes)) {
+      return input.slice(1)
+    }
+
+    return escapes + (env[key] || defaultValue(start, def, end))
   }
 
   function defaultValue (start, def, end) {
     return (start && def && end) ? replace(def.slice(2), env) : ''
   }
+}
+
+function isEscaped (escapes) {
+  return escapes.length % 2 === 1
 }

--- a/test.js
+++ b/test.js
@@ -19,3 +19,20 @@ tape('inlines env array', function (t) {
   t.same(env('hello $FOO $BAR $BAZ', maps), 'hello foo bar ')
   t.end()
 })
+
+tape('does not inline escaped', function (t) {
+  var map = {WORLD: 'world'}
+
+  t.same(env('hello \\$WORLD', map), 'hello $WORLD')
+  // JS/shell sees two backslashes (\\)
+  t.same(env('hello \\\\$WORLD', map), 'hello \\\\world')
+  t.same(env('hello \\${WORLD}', map), 'hello ${WORLD}')
+  t.same(env('hello \\$WORLD-world', map), 'hello $WORLD-world')
+  t.same(env('hello \\${WORLD:-verden}', map), 'hello ${WORLD:-verden}')
+  t.same(env('hello \\${VERDEN:-world}', map), 'hello ${VERDEN:-world}')
+  t.same(env('hello \\$VERDEN', map), 'hello $VERDEN')
+  // JS/shell sees 3 backslashes (\\\), 2 should remain (\\)
+  t.same(env('hello \\\\\\$VERDEN', map), 'hello \\\\$VERDEN')
+  t.same(env('hello \\\\\\\\\\\\\\$VERDEN', map), 'hello \\\\\\\\\\\\$VERDEN')
+  t.end()
+})


### PR DESCRIPTION
When an odd number of backslashes precede a $, the variable is not replaced.

```bash
hello \$WORLD → hello $WORLD
hello \\$WORLD → hello \\$WORLD
```

double-backslashes are passed through and not turned into single backslashes, because output of this package will probably be sent to a shell at some point—the shell can interpret the double-backslashes there. otherwise, users would end up having to escape their backslashes for the shell _and_ for the package (_and_ probably another time if this package is used in a cli).